### PR TITLE
Typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ For each of the API methods, rather than providing the parameters to the functio
 
 * `['keywords']` - either an array of keywords as strings or a string with one keyword.  If keywords is an array, the results will be returned in an array of the same order as the input.  Entering a keyword is **required**.
 
-* `country` - an optional string for the country.  Although the library can figure our the country from a formal name, it is preferred that the country is provided as a country code, for example, 'united states' should be provided as 'US', 'japan' should be provided as 'JP', etc.  If no country code is provided, 'US' is assumed by default
+* `country` - an optional string for the country.  Although the library can figure out the country from a formal name, it is preferred that the country is provided as a country code, for example, 'united states' should be provided as 'US', 'japan' should be provided as 'JP', etc.  If no country code is provided, 'US' is assumed by default
 
 #####Example
 The following example provides the top related keywords to 'dog house' in the 'US'.  Optionally, the input could have been provided as `googleTrends.topRelated({keywords: 'dog house', geo: 'US'})`.  Order of the keys does not matter and any other keys provided in the object will be ignore.
@@ -179,7 +179,7 @@ googleTrends.topRelated('dog house', 'US')
 #####Syntax
 `googleTrends.hotTrends('country')`
 
-* `country` - an optional string for the country.  Although the library can figure our the country from a formal name, it is preferred that the country is provided as a country code, for example, 'united states' should be provided as 'US', 'japan' should be provided as 'JP', etc.  If no country code is provided, 'US' is assumed by default.
+* `country` - an optional string for the country.  Although the library can figure out the country from a formal name, it is preferred that the country is provided as a country code, for example, 'united states' should be provided as 'US', 'japan' should be provided as 'JP', etc.  If no country code is provided, 'US' is assumed by default.
 
 #####Example
 The following example provides the top 20 trending searches in the 'US'.  Optionally, the input could have been provided as `googleTrends.hotTrends({geo: 'US'})`.  Any other keys provided in the object will be ignore.
@@ -229,7 +229,7 @@ googleTrends.hotTrends('US')
 #####Syntax
 `googleTrends.hotTrendsDetail('country')`
 
-* `country` - an optional string for the country.  Although the library can figure our the country from a formal name, it is preferred that the country is provided as a country code, for example, 'united states' should be provided as 'US', 'japan' should be provided as 'JP', etc.  If no country code is provided, 'US' is assumed by default.
+* `country` - an optional string for the country.  Although the library can figure out the country from a formal name, it is preferred that the country is provided as a country code, for example, 'united states' should be provided as 'US', 'japan' should be provided as 'JP', etc.  If no country code is provided, 'US' is assumed by default.
 
 #####Example
 The following example provides the top 20 trending searches in the 'US'.  Optionally, the input could have been provided as `googleTrends.hotTrendsDetail({geo: 'US'})`.  Any other keys provided in the object will be ignore.
@@ -405,7 +405,7 @@ googleTrends.top30in30()
 
 * `date` - an optional string provided as 'yyyymm'.  January === 01, December === 12.  Note that google does not aggregate the data for the current month, so the date provided must always be at least one month behind.  If no date is provided, the most recent date available is assumed.
 
-* `country` - an optional string for the country.  Although the library can figure our the country from a formal name, it is preferred that the country is provided as a country code, for example, 'united states' should be provided as 'US', 'japan' should be provided as 'JP', etc.  If no country code is provided, 'US' is assumed by default.
+* `country` - an optional string for the country.  Although the library can figure out the country from a formal name, it is preferred that the country is provided as a country code, for example, 'united states' should be provided as 'US', 'japan' should be provided as 'JP', etc.  If no country code is provided, 'US' is assumed by default.
 
 #####Example
 The following example provides the top charts in January 2016 in the 'US'.  Optionally, the input could have been provided as `googleTrends.allTopCharts({geo: 'US', date: '201601'})`.  Order of the keys does not matter and any other keys provided in the object will be ignore.
@@ -485,7 +485,7 @@ googleTrends.allTopCharts('201601', 'US')
 
 * `date` - an optional string provided as 'yyyymm'.  January === 01, December === 12.  Note that google does not aggregate the data for the current month, so the date provided must always be at least one month behind.  If no date is provided, the most recent date available is assumed.
 
-* `country` - an optional string for the country.  Although the library can figure our the country from a formal name, it is preferred that the country is provided as a country code, for example, 'united states' should be provided as 'US', 'japan' should be provided as 'JP', etc.  If no country code is provided, 'US' is assumed by default.
+* `country` - an optional string for the country.  Although the library can figure out the country from a formal name, it is preferred that the country is provided as a country code, for example, 'united states' should be provided as 'US', 'japan' should be provided as 'JP', etc.  If no country code is provided, 'US' is assumed by default.
 
 #####Example
 The following example provides the top charts for actors in January 2016 in the 'US'.  Optionally, the input could have been provided as `googleTrends.categoryTopCharts({category: 'actors', geo: 'US', date: '201601'})`.  Order of the keys does not matter and any other keys provided in the object will be ignore.

--- a/examples.js
+++ b/examples.js
@@ -22,7 +22,7 @@ var util = require('util');
 /* ~=~=~=~=~=~=~=~=~=~= hotTrends =~=~=~=~=~=~=~=~=~=~ */
 // //Parameters: takes a country as a string (optional, 'US' is default)
 // // optionally as the first argument pass an object: {geo: 'US'}
-// googleTrends.hotTrends('ZZ')
+// googleTrends.hotTrends('US')
 // .then(function(results){
 // 	console.log("these are the results", results);
 // })

--- a/src/resources/callbacks.js
+++ b/src/resources/callbacks.js
@@ -16,7 +16,7 @@ function getParamNames(func) {
 }
 
 function parseArguments(args, func){
-	args = Array.isArray(args) ? args : Array.prototype.slice.call(args);
+	args = Array.prototype.slice.call(args);
 	var parameters = getParamNames(func);
 
 	var returnObj = parameters.reduce(function(acc, curr, index){

--- a/src/resources/callbacks.js
+++ b/src/resources/callbacks.js
@@ -16,7 +16,7 @@ function getParamNames(func) {
 }
 
 function parseArguments(args, func){
-	args = Array.prototype.slice.call(args);
+	args = Array.isArray(args) ? args : Array.prototype.slice.call(args);
 	var parameters = getParamNames(func);
 
 	var returnObj = parameters.reduce(function(acc, curr, index){

--- a/test/resources/dateValidate.test.js
+++ b/test/resources/dateValidate.test.js
@@ -18,11 +18,11 @@ describe('dateValidate.test.js', function(){
 			var day = today.getDate();
 			var date = "";
 
-			month = day < 7 ? month - 1 : month;
+			month = month - 1;
 			
-			if(month === 0){
+			if(month <= 0){
 				year -= 1;
-				month = 12;
+				month = month + 12;
 			}
 			date += year;
 			if(month < 10) date += "0";


### PR DESCRIPTION
* Fixed typo in readme `our the country` --our--  correction: `out the country`
* Fixed error in examples, country `US` rather than `ZZ`
* Fixed date test