### PR TITLE
international dateformat fix

### DIFF
--- a/src/resources/htmlParser.js
+++ b/src/resources/htmlParser.js
@@ -59,7 +59,7 @@ function parseJSON(htmlString) {
         }
         for (let j = 0; j < parsedTrends.table.rows.length; j++) {
             var data = parsedTrends.table.rows[j].c,
-                date = new Date(data[0].f);
+                date = new Date(data[0].v);
             for (let k = 1; k < data.length; k++) {
                 if (data[k]) {
                     trendsData[k - 1].values.push({


### PR DESCRIPTION
data[0].f is a location specific string which cannot always be parsed by .toISOString(). Therefore I propose to use the data[0].v field, which contains an ISO 8601 timestamp, instead.