### PR TITLE
Enable Proxy Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Optional callback function where the first parameter is an error and the second 
 * [API](#api)
   * [Promises](#promises)
   * [Callbacks](#callbacks)
+  * [Proxy Server](#proxy-server)
   * [Examples](#examples)
   * [API Methods](#api-methods)
     * [autoComplete](#autocomplete)
@@ -98,6 +99,27 @@ googleTrends.interestOverTime({keyword: 'Women\'s march'}, function(err, results
 })
 ```
 
+### Proxy Server
+A proxy server can be used by specifying an http agent as part of the query.
+
+```js
+const HttpsProxyAgent = require('https-proxy-agent');
+
+let proxyAgent =  new HttpsProxyAgent('http://proxy-host:8888/');
+
+let query = {
+    keyword: 'Women\'s march',
+    agent: proxyAgent
+};
+
+googleTrends.interestOverTime(query)
+.then(function(results){
+  console.log('These proxied results are incredible', results);
+})
+.catch(function(err){
+  console.error('Oh no there was an error, double check your proxy settings', err);
+});
+```
 
 ### Multiple Keywords
 Compare multiple keywords with any of the api methods by supplying an `array` instead of a single `string`

--- a/src/request.js
+++ b/src/request.js
@@ -2,12 +2,14 @@
 import https from 'https';
 import querystring from 'querystring';
 
-export default function request({method, host, path, qs}) {
+export default function request({method, host, path, qs, agent}) {
   const options = {
     host,
     method,
     path: `${path}?${querystring.stringify(qs)}`,
   };
+
+  if (agent) options.agent = agent;
 
   return new Promise((resolve, reject) => {
     const req = https.request(options, (res) => {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -170,6 +170,8 @@ export function getResults(request) {
       },
     };
 
+    if (obj.agent) options.agent = obj.agent;
+
     const { path, resolution, _id } = map[searchType];
 
     return request(options)


### PR DESCRIPTION
Thanks for the great work on this Google Trends API, worked painlessly.  However, I found I needed proxy support to be able to complete my task.  

I modified the source and included is a pull request that makes it possible to include an agent value as part of the query, allowing specifying a proxy agent to the https request module.