### PR TITLE
Fixed an issue with using a proxy agent that happened when making a m…

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -161,6 +161,17 @@ export function getResults(request) {
       },
     };
 
+    // going to modify it don't want to affect the callers data
+    obj = Object.assign({}, obj);
+    let agent = null;
+
+    // formatKeywords will incorporate the agent into the comparisionItem
+    // so remove it first
+    if (obj.agent) {
+      agent = obj.agent;
+      delete obj.agent;
+    }
+
     const options = {
       method: 'GET',
       host: 'trends.google.com',
@@ -176,7 +187,7 @@ export function getResults(request) {
       },
     };
 
-    if (obj.agent) options.agent = obj.agent;
+    options.agent = agent;
 
     const { path, resolution, _id } = map[searchType];
 


### PR DESCRIPTION
There was an issue with the proxy agent change that broke multiple keyword queries when an agent was used.  This change fixes that problem.  

Because I needed to remove the agent from the obj before the call to formatKeywords, I am cloning the obj so as not to modify the callers data structure and create a side-effect.   It did not seem appropriate to add the logic to formatKeywords to filter out the agent.

