### PR TITLE
fixes 429 errors from trends.google.com

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -2,6 +2,29 @@
 import https from 'https';
 import querystring from 'querystring';
 
+// cache of the cookie - avoid re-requesting on subsequent requests.
+let cookieVal;
+
+// simpler request method for avoiding double-promise confusion
+function rereq(options, done) {
+  let req;
+
+  req = https.request(options, (res) => {
+    let chunk = '';
+
+    res.on('data', (data) => {
+      chunk += data;
+    });
+    res.on('end', () => {
+      done(null, chunk.toString('utf8'));
+    });
+  });
+  req.on('error', (e) => {
+    done(e);
+  });
+  req.end();
+}
+
 export default function request({method, host, path, qs, agent}) {
   const options = {
     host,
@@ -10,6 +33,8 @@ export default function request({method, host, path, qs, agent}) {
   };
 
   if (agent) options.agent = agent;
+  // will use cached cookieVal if set on 429 error
+  if (cookieVal) options.headers = {'cookie': cookieVal};
 
   return new Promise((resolve, reject) => {
     const req = https.request(options, (res) => {
@@ -20,7 +45,18 @@ export default function request({method, host, path, qs, agent}) {
       });
 
       res.on('end', () => {
-        resolve(chunk.toString('utf8'));
+        if (res.statusCode === 429 && res.headers['set-cookie']) {
+          // Fix for the "too many requests" issue
+          // Look for the set-cookie header and re-request
+          cookieVal = res.headers['set-cookie'][0].split(';')[0];
+          options.headers = {'cookie': cookieVal};
+          rereq(options, function(err, response) {
+            if (err) return reject(err);
+            resolve(response);
+          });
+        } else {
+          resolve(chunk.toString('utf8'));
+        }
       });
     });
 


### PR DESCRIPTION
by checking for that status code, and storing and using the set-cookie value for an immediate re-request, and subsequent requests.

Should fix https://github.com/pat310/google-trends-api/issues/105 as per some discussion there. Let me know if you think any test script updates would apply for this fix.