### PR TITLE
Search for the same keyword over multiple locations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Requires an `object` as the first parameter with the following keys:
 * `keyword` - **required** - type `string` or `array` - the search term(s) of interest
 * `startTime` - *optional* - type `Date` object - the start of the time range of interest (defaults to `new Date('2004-01-01')` if not supplied)
 * `endTime` - *optional* - type `Date` object - the end of the time range of interest (defaults to `new Date(Date.now())` if not supplied)
-* `geo` - *optional* - type `string` or `array` - geocode(s) for a country, region, or DMA depending on the granularity required (defaults to worldwide).For example, `geo: 'US-CA-800'` will target the Bakersfield, California, United States or `geo: 'US'` will just target the US.
+* `geo` - *optional* - type `string` or `array` - geocode(s) for a country, region, or DMA depending on the granularity required (defaults to worldwide).For example, `geo: 'US-CA-800'` will target the Bakersfield, California, United States or `geo: 'US'` will just target the US. Providing an array of geocodes with a single keyword will search for that keyword in all of the provided locations.
 * `hl` - *optional* - type `string` - preferred language code for results (defaults to english)
 * `timezone` - *optional* - type `number` - preferred timezone (defaults to the time zone difference, in minutes, from UTC to current locale (host system settings))
 * `category` - *optional* - type `number` - a number corresponding to a particular category to query within (defaults to all categories), see the [category wiki](https://github.com/pat310/google-trends-api/wiki/Google-Trends-Categories) for a complete list

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Requires an `object` as the first parameter with the following keys:
 * `keyword` - **required** - type `string` or `array` - the search term(s) of interest
 * `startTime` - *optional* - type `Date` object - the start of the time range of interest (defaults to `new Date('2004-01-01')` if not supplied)
 * `endTime` - *optional* - type `Date` object - the end of the time range of interest (defaults to `new Date(Date.now())` if not supplied)
-* `geo` - *optional* - type `string` or `array` - geocode(s) for a country, region, or DMA depending on the granularity required (defaults to worldwide).For example, `geo: 'US-CA-800'` will target the Bakersfield, California, United States or `geo: 'US'` will just target the US. Providing an array of geocodes with a single keyword will search for that keyword in all of the provided locations.
+* `geo` - *optional* - type `string` or `array` - geocode(s) for a country, region, or DMA depending on the granularity required (defaults to worldwide). For example, `geo: 'US-CA-800'` will target the Bakersfield, California, United States or `geo: 'US'` will just target the US. Passing `geo: ['US-CA, US-VA'], keyword: ['wine', 'peanuts']` will search for wine in California and peanuts in Virginia.
 * `hl` - *optional* - type `string` - preferred language code for results (defaults to english)
 * `timezone` - *optional* - type `number` - preferred timezone (defaults to the time zone difference, in minutes, from UTC to current locale (host system settings))
 * `category` - *optional* - type `number` - a number corresponding to a particular category to query within (defaults to all categories), see the [category wiki](https://github.com/pat310/google-trends-api/wiki/Google-Trends-Categories) for a complete list
@@ -269,7 +269,7 @@ Requires an `object` as the first parameter with the following keys:
 * `keyword` - **required** - type `string` or `array` - the search term(s) of interest
 * `startTime` - *optional* - type `Date` object - the start of the time range of interest (defaults to `new Date('2004-01-01')` if not supplied)
 * `endTime` - *optional* - type `Date` object - the end of the time range of interest (defaults to `new Date(Date.now())` if not supplied)
-* `geo` - *optional* - type `string` or `array` - geocode(s) for a country, region, or DMA depending on the granularity required (defaults to worldwide). For example, `geo: 'US-CA-800'` will target the Bakersfield, California, United States or `geo: 'US'` will just target the US.
+* `geo` - *optional* - type `string` or `array` - geocode(s) for a country, region, or DMA depending on the granularity required (defaults to worldwide). For example, `geo: 'US-CA-800'` will target the Bakersfield, California, United States or `geo: 'US'` will just target the US. Passing `geo: ['US-CA, US-VA'], keyword: ['wine', 'peanuts']` will search for wine in California and peanuts in Virginia.
 * `resolution` - *optional* - type `enumerated string` either `COUNTRY`, `REGION`, `CITY` or `DMA`.  Resolution is selected by default otherwise.  Trying to select a resolution larger than a specified `geo` will return an error.
 * `hl` - *optional* - type `string` - preferred language code for results (defaults to english)
 for results (defaults to english)
@@ -334,7 +334,7 @@ Requires an `object` as the first parameter with the following keys:
 * `keyword` - **required** - type `string` or `array` - the search term(s) of interest
 * `startTime` - *optional* - type `Date` object - the start of the time range of interest (defaults to `new Date('2004-01-01')` if not supplied)
 * `endTime` - *optional* - type `Date` object - the end of the time range of interest (defaults to `new Date(Date.now())` if not supplied)
-* `geo` - *optional* - type `string` or `array` - geocode(s) for a country, region, or DMA depending on the granularity required (defaults to worldwide). For example, `geo: 'US-CA-800'` will target the Bakersfield, California, United States or `geo: 'US'` will just target the US.
+* `geo` - *optional* - type `string` or `array` - geocode(s) for a country, region, or DMA depending on the granularity required (defaults to worldwide). For example, `geo: 'US-CA-800'` will target the Bakersfield, California, United States or `geo: 'US'` will just target the US. Passing `geo: ['US-CA, US-VA'], keyword: ['wine', 'peanuts']` will search for wine in California and peanuts in Virginia.
 * `hl` - *optional* - type `string` - preferred language code for results (defaults to english)
 for results (defaults to english)
 * `timezone` - *optional* - type `number` - preferred timezone (defaults to the time zone difference, in minutes, from UTC to current locale (host system settings))
@@ -379,7 +379,7 @@ Requires an `object` as the first parameter with the following keys:
 * `keyword` - **required** - type `string` or `array` - the search term(s) of interest
 * `startTime` - *optional* - type `Date` object - the start of the time range of interest (defaults to `new Date('2004-01-01')` if not supplied)
 * `endTime` - *optional* - type `Date` object - the end of the time range of interest (defaults to `new Date(Date.now())` if not supplied)
-* `geo` - *optional* - type `string` or `array` - geocode(s) for a country, region, or DMA depending on the granularity required (defaults to worldwide). For example, `geo: 'US-CA-800'` will target the Bakersfield, California, United States or `geo: 'US'` will just target the US.
+* `geo` - *optional* - type `string` or `array` - geocode(s) for a country, region, or DMA depending on the granularity required (defaults to worldwide). For example, `geo: 'US-CA-800'` will target the Bakersfield, California, United States or `geo: 'US'` will just target the US. Passing `geo: ['US-CA, US-VA'], keyword: ['wine', 'peanuts']` will search for wine in California and peanuts in Virginia.
 * `hl` - *optional* - type `string` - preferred language code for results (defaults to english)
 for results (defaults to english)
 * `timezone` - *optional* - type `number` - preferred timezone (defaults to the time zone difference, in minutes, from UTC to current locale (host system settings))

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -120,9 +120,16 @@ export function parseResults(results) {
  * @return {Array}     Returns an array of comparisonItems
  */
 export function formatComparisonItems(obj) {
+  const isMultiRegion = obj.geo && Array.isArray(obj.geo);
+  const isMultiKeyword = () => Array.isArray(obj.keyword);
+
+  // Duplicate keywords to match the length of geo
+  if (isMultiRegion && !isMultiKeyword()) {
+    obj.keyword = Array(obj.geo.length).fill(obj.keyword);
+  }
 
   // If we are requesting an array of keywords for comparison
-  if (Array.isArray(obj.keyword)) {
+  if (isMultiKeyword()) {
 
     // Map the keywords to the items array
     let items = obj.keyword.reduce((arr, keyword) => {
@@ -133,7 +140,7 @@ export function formatComparisonItems(obj) {
     }, []);
 
     // Is there an array of regions as well?
-    if (obj.geo && Array.isArray(obj.geo)) {
+    if (isMultiRegion) {
 
       obj.geo.forEach((region, index) => {
         items[index].geo = region;

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -121,15 +121,16 @@ export function parseResults(results) {
  */
 export function formatComparisonItems(obj) {
   const isMultiRegion = obj.geo && Array.isArray(obj.geo);
-  const isMultiKeyword = () => Array.isArray(obj.keyword);
+  let isMultiKeyword = Array.isArray(obj.keyword);
 
   // Duplicate keywords to match the length of geo
-  if (isMultiRegion && !isMultiKeyword()) {
+  if (isMultiRegion && !isMultiKeyword) {
     obj.keyword = Array(obj.geo.length).fill(obj.keyword);
+    isMultiKeyword = true;
   }
 
   // If we are requesting an array of keywords for comparison
-  if (isMultiKeyword()) {
+  if (isMultiKeyword) {
 
     // Map the keywords to the items array
     let items = obj.keyword.reduce((arr, keyword) => {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -59,6 +59,12 @@ export function constructObj(obj, cbFunc) {
     obj = new Error('Callback function must be a function');
   }
 
+  const multiGeoKeyword = Array.isArray(obj.geo) && Array.isArray(obj.keyword);
+
+  if (multiGeoKeyword && obj.geo.length !== obj.keyword.length) {
+    obj = new Error('Geo length must be equal to keyword length');
+  }
+
   if (!obj.hl) obj.hl = 'en-US';
   if (!obj.category) obj.category = 0;
   if (!obj.timezone) obj.timezone = new Date().getTimezoneOffset();

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -154,6 +154,18 @@ describe('utilities', () => {
       ]);
     });
 
+    it('should duplicate single keyword searches for multiple regions', () => {
+      let keywords = formatComparisonItems({
+        keyword: 'test',
+        startDate: '2018-01-01',
+        geo: ['US-MA', 'US-VA'],
+      });
+
+      expect(keywords).to.deep.equal([
+        {keyword: 'test', startDate: '2018-01-01', geo: 'US-MA'},
+        {keyword: 'test', startDate: '2018-01-01', geo: 'US-VA'},
+      ]);
+    });
   });
 
   describe('constructObj', () => {

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -45,18 +45,6 @@ describe('utilities', () => {
   });
 
   describe('formatTime', () => {
-    it('should return an error if startTime is not a date object', () => {
-      const obj = {startTime: '2017-02-04'};
-
-      expect(formatTime(obj)).to.be.an('error');
-    });
-
-    it('should return an error if endTime is not a date object', () => {
-      const obj = {endTime: '2017-02-04'};
-
-      expect(formatTime(obj)).to.be.an('error');
-    });
-
     it('should make endTime the current date if not provided', () => {
       const d = new Date();
       const endTime = convertDateToString(d);
@@ -182,6 +170,20 @@ describe('utilities', () => {
       expect(constructObj({
         keyword: ['foo', 'bar'],
         geo: ['Brooklyn', 'DC', 'Boston'],
+      }).obj).to.be.an('error');
+    });
+
+    it('should return an error if startTime is not a date', () => {
+      expect(constructObj({
+        keyword: 'test',
+        startTime: '2018-01-01',
+      }).obj).to.be.an('error');
+    });
+
+    it('should return an error if endTime is not a date', () => {
+      expect(constructObj({
+        keyword: 'test',
+        endTime: '2018-01-01',
       }).obj).to.be.an('error');
     });
 

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -178,6 +178,13 @@ describe('utilities', () => {
       expect(constructObj({keywords: 'Brooklyn'}).obj).to.be.an('error');
     });
 
+    it('should return an error if keyword and geo length are not equal', () => {
+      expect(constructObj({
+        keyword: ['foo', 'bar'],
+        geo: ['Brooklyn', 'DC', 'Boston'],
+      }).obj).to.be.an('error');
+    });
+
     it('should return an error if cbFunc is not a function', () => {
       expect(constructObj({keyword: 'Brooklyn'}, 'str').obj).to.be.an('error');
     });


### PR DESCRIPTION
This adds support for a single *keyword* string with an array of *geo* locations.

I ran into error `SyntaxError: Unexpected token C in JSON at position 0` when running a query such as:

```javascript
googleTrends.interestOverTime({
  keyword: 'javascript',
  startTime: new Date('2018-01-01'),
  geo: ['US-MA', 'US-VA']
});
```

My solution to this was to search for the same `keyword` for all regions in the case when keyword is a string while `geo` is an array.

@pat310 Let me know if you think this is a good change, thanks!