### PR TITLE
fix: Fix for the "too many requests" issue

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -45,11 +45,12 @@ export default function request({method, host, path, qs, agent}) {
       });
 
       res.on('end', () => {
-        if (res.statusCode === 429 && res.headers['set-cookie']) {
+        if (res.statusCode === 429) {
           // Fix for the "too many requests" issue
           // Look for the set-cookie header and re-request
-          cookieVal = res.headers['set-cookie'][0].split(';')[0];
-          options.headers = {'cookie': cookieVal};
+          cookieVal = res.headers['set-cookie'] ?
+            res.headers['set-cookie'][0].split(';')[0] : '';
+          options.headers = cookieVal ? {'cookie': cookieVal} : {};
           rereq(options, function(err, response) {
             if (err) return reject(err);
             resolve(response);

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -162,6 +162,10 @@ export function parseResults(results) {
  * @return {Array}     Returns an array of comparisonItems
  */
 export function formatComparisonItems(obj) {
+  // fix the querystring has the agent param from obj
+  obj = Object.assign({}, obj);
+  delete obj.agent;
+
   const isMultiRegion = obj.geo && Array.isArray(obj.geo);
   let isMultiKeyword = Array.isArray(obj.keyword);
 


### PR DESCRIPTION
there is no cookie header in  google trends api response when return 429, so the cookie must be clear first in the request, then will receive the cookie next request.

<img width="711" alt="429 header" src="https://user-images.githubusercontent.com/1575657/196217818-e04c4d63-0cbf-4ca6-83d9-a6f7571c10ba.png">

 close #165
 close #164 